### PR TITLE
change master to main

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -159,7 +159,7 @@ workflows:
             - test
           filters:
             branches:
-              only: master
+              only: main
       - deploy-release:
           requires:
             - test


### PR DESCRIPTION
Circle didn't deploy because I had the branch set to `master` instead of `main`. Fix that.