### PR TITLE
Add some password information

### DIFF
--- a/gmd-sdk/certs/README.md
+++ b/gmd-sdk/certs/README.md
@@ -1,0 +1,13 @@
+# Certificates
+
+Included here are several self signed certificates to be used for testing only.
+Do *NOT* use these certificates in production code.
+
+## Passwords
+
+Some of the passwords that will be needed to make the flows work are:
+
+| Filename      | Password       |
+|---------------|----------------|
+| `nifinpe.jks` | `bmlmaXVzZXIK` |
+| `rootCA.jks`  | `devotion`     |


### PR DESCRIPTION
Add some documentation for certificate password information that will be needed to properly run the flows.

Closes #66 